### PR TITLE
feat(lint): allow ignoring helm lint messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Helm-ls is a [helm](https://github.com/helm/helm) language server protocol [LSP]
 - [Configuration options](#configuration-options)
   - [General](#general)
   - [Values Files](#values-files-1)
+  - [Helm Lint](#helm-lint)
   - [yaml-language-server config](#yaml-language-server-config)
   - [Default Configuration](#default-configuration)
 - [Editor Config examples](#editor-config-examples)
@@ -183,6 +184,11 @@ You can configure helm-ls with lsp workspace configurations.
 - **Lint Overlay Values File**: Path to the lint overlay values file, which will be merged with the main values file for linting
 - **Additional Values Files Glob Pattern**: Pattern for additional values files, which will be shown for completion and hover
 
+### Helm Lint
+
+- **Enabled**: Allows to disable the diagnostics gathered with helm lint.
+- **ignoredMessages**: A list of lint messages to ignore. You can for example add "icon is recommended" here.
+
 ### yaml-language-server config
 
 - **Enable yaml-language-server**: Toggle support of this feature.
@@ -209,6 +215,10 @@ settings = {
       mainValuesFile = "values.yaml",
       lintOverlayValuesFile = "values.lint.yaml",
       additionalValuesFilesGlobPattern = "values*.yaml"
+    },
+    helmLint = {
+      enabled = true,
+      ignoredMessages = {},
     },
     yamlls = {
       enabled = true,

--- a/cmds/lint.go
+++ b/cmds/lint.go
@@ -26,7 +26,7 @@ func newLintCmd() *cobra.Command {
 				return err
 			}
 
-			msgs := helmlint.GetDiagnostics(rootPath, chart.ValuesFiles.MainValuesFile.Values)
+			msgs := helmlint.GetDiagnostics(rootPath, chart.ValuesFiles.MainValuesFile.Values, []string{})
 
 			for _, msg := range msgs {
 				fmt.Println(msg)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -63,7 +63,7 @@ func newHandler(connPool jsonrpc2.Conn, client protocol.Client) *ServerHandler {
 	chartStore := charts.NewChartStore(uri.File(currentDir), charts.NewChart, handler.AddChartCallback)
 	handler.chartStore = chartStore
 	handler.langHandlers = map[document.DocumentType]LangHandler{
-		document.TemplateDocumentType: templatehandler.NewTemplateHandler(client, documents, chartStore),
+		document.TemplateDocumentType: templatehandler.NewTemplateHandler(client, documents, chartStore, handler.helmlsConfig.HelmLintConfig),
 		document.YamlDocumentType:     yamlhandler.NewYamlHandler(client, documents, chartStore),
 	}
 

--- a/internal/handler/template_handler/configure.go
+++ b/internal/handler/template_handler/configure.go
@@ -9,6 +9,7 @@ import (
 
 func (h *TemplateHandler) Configure(ctx context.Context, helmlsConfig util.HelmlsConfiguration) {
 	h.configureYamlls(ctx, helmlsConfig.YamllsConfiguration)
+	h.helmlintConfig = helmlsConfig.HelmLintConfig
 }
 
 func (h *TemplateHandler) configureYamlls(ctx context.Context, config util.YamllsConfiguration) {

--- a/internal/handler/template_handler/diagnostics.go
+++ b/internal/handler/template_handler/diagnostics.go
@@ -19,6 +19,6 @@ func (h *TemplateHandler) GetDiagnostics(uri lsp.DocumentURI) []lsp.PublishDiagn
 	if chart == nil {
 		return []lsp.PublishDiagnosticsParams{}
 	}
-	notifications := helmlint.GetDiagnosticsNotifications(chart, doc)
+	notifications := helmlint.GetDiagnosticsNotifications(chart, doc, &h.helmlintConfig)
 	return notifications
 }

--- a/internal/handler/template_handler/diagnostics.go
+++ b/internal/handler/template_handler/diagnostics.go
@@ -19,6 +19,6 @@ func (h *TemplateHandler) GetDiagnostics(uri lsp.DocumentURI) []lsp.PublishDiagn
 	if chart == nil {
 		return []lsp.PublishDiagnosticsParams{}
 	}
-	notifications := helmlint.GetDiagnosticsNotifications(chart, doc, &h.helmlintConfig)
+	notifications := helmlint.GetDiagnosticsNotifications(chart, doc, h.helmlintConfig)
 	return notifications
 }

--- a/internal/handler/template_handler/template_handler.go
+++ b/internal/handler/template_handler/template_handler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/mrjosh/helm-ls/internal/charts"
 	"github.com/mrjosh/helm-ls/internal/log"
 	"github.com/mrjosh/helm-ls/internal/lsp/document"
+	"github.com/mrjosh/helm-ls/internal/util"
 	"go.lsp.dev/protocol"
 )
 
@@ -15,14 +16,16 @@ type TemplateHandler struct {
 	documents       *document.DocumentStore
 	chartStore      *charts.ChartStore
 	yamllsConnector *yamlls.Connector
+	helmlintConfig  util.HelmLintConfig
 }
 
-func NewTemplateHandler(client protocol.Client, documents *document.DocumentStore, chartStore *charts.ChartStore) *TemplateHandler {
+func NewTemplateHandler(client protocol.Client, documents *document.DocumentStore, chartStore *charts.ChartStore, helmlintConfig util.HelmLintConfig) *TemplateHandler {
 	return &TemplateHandler{
 		client:          client,
 		documents:       documents,
 		chartStore:      chartStore,
 		yamllsConnector: &yamlls.Connector{},
+		helmlintConfig:  helmlintConfig,
 	}
 }
 

--- a/internal/helm_lint/lint.go
+++ b/internal/helm_lint/lint.go
@@ -20,7 +20,7 @@ import (
 
 var logger = log.GetLogger()
 
-func GetDiagnosticsNotifications(chart *charts.Chart, doc *document.TemplateDocument, helmLintConfig *util.HelmLintConfig) []lsp.PublishDiagnosticsParams {
+func GetDiagnosticsNotifications(chart *charts.Chart, doc *document.TemplateDocument, helmLintConfig util.HelmLintConfig) []lsp.PublishDiagnosticsParams {
 	if !helmLintConfig.Enabled {
 		return []lsp.PublishDiagnosticsParams{}
 	}

--- a/internal/helm_lint/lint_test.go
+++ b/internal/helm_lint/lint_test.go
@@ -38,7 +38,7 @@ func TestLintNotifications(t *testing.T) {
 		Document: document.Document{
 			URI: uri.File("../../testdata/example/templates/deployment-no-templates.yaml"),
 		},
-	}, &util.HelmLintConfig{Enabled: true})
+	}, util.HelmLintConfig{Enabled: true})
 	assert.NotEmpty(t, diagnostics)
 	assert.Len(t, diagnostics, 3)
 
@@ -66,7 +66,7 @@ func TestLintNotificationsIncludesEmptyDiagnosticsForFixedIssues(t *testing.T) {
 	}
 	diagnostics := GetDiagnosticsNotifications(&chart, &document.TemplateDocument{
 		Document: document.Document{URI: uri.File("../../testdata/example/templates/deployment-no-templates.yaml")},
-	}, &util.HelmLintConfig{Enabled: true})
+	}, util.HelmLintConfig{Enabled: true})
 
 	uris := []string{}
 	for _, notification := range diagnostics {
@@ -89,6 +89,6 @@ func TestLintNotificationsDisabled(t *testing.T) {
 		Document: document.Document{
 			URI: uri.File("../../testdata/example/templates/deployment-no-templates.yaml"),
 		},
-	}, &util.HelmLintConfig{Enabled: false})
+	}, util.HelmLintConfig{Enabled: false})
 	assert.Empty(t, diagnostics)
 }

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -7,6 +7,7 @@ import (
 type HelmlsConfiguration struct {
 	YamllsConfiguration YamllsConfiguration `json:"yamlls,omitempty"`
 	ValuesFilesConfig   ValuesFilesConfig   `json:"valuesFiles,omitempty"`
+	HelmLintConfig      HelmLintConfig      `json:"helmLint,omitempty"`
 	LogLevel            string              `json:"logLevel,omitempty"`
 }
 
@@ -14,6 +15,11 @@ type ValuesFilesConfig struct {
 	MainValuesFileName               string `json:"mainValuesFile,omitempty"`
 	LintOverlayValuesFileName        string `json:"lintOverlayValuesFile,omitempty"`
 	AdditionalValuesFilesGlobPattern string `json:"additionalValuesFilesGlobPattern,omitempty"`
+}
+
+type HelmLintConfig struct {
+	Enabled         bool     `json:"enabled,omitempty"`
+	IgnoredMessages []string `json:"ignoredMessages,omitempty"`
 }
 
 type YamllsConfiguration struct {
@@ -47,6 +53,10 @@ var DefaultConfig = HelmlsConfiguration{
 		MainValuesFileName:               "values.yaml",
 		LintOverlayValuesFileName:        "values.lint.yaml",
 		AdditionalValuesFilesGlobPattern: "values*.yaml",
+	},
+	HelmLintConfig: HelmLintConfig{
+		Enabled:         true,
+		IgnoredMessages: []string{},
 	},
 	YamllsConfiguration: YamllsConfiguration{
 		Enabled:                   true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration options to enable or disable Helm lint diagnostics and to ignore specific lint messages.
- **Documentation**
  - Updated documentation to describe new Helm lint configuration options, including usage examples and table of contents links.
- **Tests**
  - Enhanced test coverage to verify Helm lint configuration behavior, including message ignoring and disabling diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->