### PR TITLE
Fix/yaml ls path option array

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You can configure helm-ls with lsp workspace configurations.
 
 - **Enable yaml-language-server**: Toggle support of this feature.
 - **EnabledForFilesGlob**: A glob pattern defining for which files yaml-language-server should be enabled.
-- **Path to yaml-language-server**: Specify the executable location.
+- **Path to yaml-language-server**: Specify the executable location. Can be a string or an array.
 - **initTimeoutSeconds**: The timeout in seconds for the initialization of yamlls. (Increase if you get an error log like "Error initializing yamlls context deadline exceeded")
 - **Diagnostics Settings**:
 
@@ -225,7 +225,7 @@ settings = {
       enabledForFilesGlob = "*.{yaml,yml}",
       diagnosticsLimit = 50,
       showDiagnosticsDirectly = false,
-      path = "yaml-language-server",
+      path = "yaml-language-server", -- or something like { "node", "yaml-language-server.js" }
       initTimeoutSeconds = 3,
       config = {
         schemas = {

--- a/internal/adapter/yamlls/yamlls.go
+++ b/internal/adapter/yamlls/yamlls.go
@@ -35,9 +35,19 @@ func NewConnector(ctx context.Context,
 	documents *document.DocumentStore,
 	customHandler *CustomHandler,
 ) *Connector {
+	yamllsCommand := "yaml-language-server"
+	if len(yamllsConfiguration.Path) > 0 {
+		yamllsCommand = yamllsConfiguration.Path[0]
+	}
+
+	yamllsArgs := []string{"--stdio"}
+	if len(yamllsConfiguration.Path) > 1 {
+		yamllsArgs = append(yamllsConfiguration.Path[1:], yamllsArgs...)
+	}
+
 	yamllsCmd := exec.Command(
-		yamllsConfiguration.Path[0],
-		append(yamllsConfiguration.Path[1:], "--stdio")...,
+		yamllsCommand,
+		yamllsArgs...,
 	)
 
 	stdin, err := yamllsCmd.StdinPipe()

--- a/internal/adapter/yamlls/yamlls.go
+++ b/internal/adapter/yamlls/yamlls.go
@@ -35,19 +35,9 @@ func NewConnector(ctx context.Context,
 	documents *document.DocumentStore,
 	customHandler *CustomHandler,
 ) *Connector {
-	yamllsCommand := "yaml-language-server"
-	if len(yamllsConfiguration.Path) > 0 {
-		yamllsCommand = yamllsConfiguration.Path[0]
-	}
-
-	yamllsArgs := []string{"--stdio"}
-	if len(yamllsConfiguration.Path) > 1 {
-		yamllsArgs = append(yamllsConfiguration.Path[1:], yamllsArgs...)
-	}
-
 	yamllsCmd := exec.Command(
-		yamllsCommand,
-		yamllsArgs...,
+		yamllsConfiguration.Path.GetExecutable(),
+		yamllsConfiguration.Path.GetArgs()...,
 	)
 
 	stdin, err := yamllsCmd.StdinPipe()

--- a/internal/adapter/yamlls/yamlls.go
+++ b/internal/adapter/yamlls/yamlls.go
@@ -35,7 +35,10 @@ func NewConnector(ctx context.Context,
 	documents *document.DocumentStore,
 	customHandler *CustomHandler,
 ) *Connector {
-	yamllsCmd := exec.Command(yamllsConfiguration.Path, "--stdio")
+	yamllsCmd := exec.Command(
+		yamllsConfiguration.Path[0],
+		append(yamllsConfiguration.Path[1:], "--stdio")...,
+	)
 
 	stdin, err := yamllsCmd.StdinPipe()
 	if err != nil {

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -49,6 +49,25 @@ func (p *YamllsPath) UnmarshalJSON(data []byte) error {
 	}
 }
 
+func (p *YamllsPath) GetExecutable() string {
+	if len(*p) > 0 {
+		return (*p)[0]
+	}
+	return "yaml-language-server"
+}
+
+func (p *YamllsPath) GetArgs() []string {
+	requiredArgs := []string{"--stdio"}
+	if len(*p) > 1 {
+		if (*p)[len(*p)-1] == "--stdio" {
+			return (*p)[1:]
+		} else {
+			return append((*p)[1:], requiredArgs...)
+		}
+	}
+	return requiredArgs
+}
+
 type YamllsConfiguration struct {
 	Enabled                   bool   `json:"enabled,omitempty"`
 	EnabledForFilesGlob       string `json:"enabledForFilesGlob,omitempty"`

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYamllsPath_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedError error
+		expected      YamllsPath
+	}{
+		{
+			name:     "single string",
+			input:    `"yaml-language-server"`,
+			expected: YamllsPath{"yaml-language-server"},
+		},
+		{
+			name:     "string array",
+			input:    `["yaml-language-server", "--foo", "--bar"]`,
+			expected: YamllsPath{"yaml-language-server", "--foo", "--bar"},
+		},
+		{
+			name:     "string array",
+			input:    `["node","yaml-language-server.js", "--foo", "--bar"]`,
+			expected: YamllsPath{"node", "yaml-language-server.js", "--foo", "--bar"},
+		},
+		{
+			name:          "error",
+			input:         `{}`,
+			expectedError: &json.UnmarshalTypeError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var path YamllsPath
+			err := json.Unmarshal([]byte(tt.input), &path)
+
+			if tt.expectedError != nil {
+				var ute *json.UnmarshalTypeError
+				assert.ErrorAs(t, err, &ute)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, path)
+		})
+	}
+}

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -52,3 +52,55 @@ func TestYamllsPath_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestYamllsPath_GetExecutable(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     YamllsPath
+		expected string
+	}{
+		{"empty path", YamllsPath{}, "yaml-language-server"},
+		{"non-empty path", YamllsPath{"custom-server", "--flag"}, "custom-server"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.path.GetExecutable())
+		})
+	}
+}
+
+func TestYamllsPath_GetArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     YamllsPath
+		expected []string
+	}{
+		{
+			"empty path",
+			YamllsPath{},
+			[]string{"--stdio"},
+		},
+		{
+			"only executable",
+			YamllsPath{"custom-server"},
+			[]string{"--stdio"},
+		},
+		{
+			"executable with args (last is --stdio)",
+			YamllsPath{"custom-server", "--foo", "--stdio"},
+			[]string{"--foo", "--stdio"},
+		},
+		{
+			"executable with args (last not --stdio)",
+			YamllsPath{"custom-server", "--foo"},
+			[]string{"--foo", "--stdio"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.path.GetArgs())
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now configure the yaml-language-server path as either a single string or an array (executable plus arguments). Backward compatible with existing configs; defaults to yaml-language-server. Multi-argument commands are supported and --stdio is handled automatically.
- Documentation
  - README updated to show both string and array examples for the yaml-language-server path configuration, with clarifying notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->