### PR TITLE
feat: allow setting yamlls path via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You can configure helm-ls with lsp workspace configurations.
 
 - **Enable yaml-language-server**: Toggle support of this feature.
 - **EnabledForFilesGlob**: A glob pattern defining for which files yaml-language-server should be enabled.
-- **Path to yaml-language-server**: Specify the executable location. Can be a string or an array. Can also be set with the environment variable `YAMLLS_PATH`.
+- **Path to yaml-language-server**: Specify the executable location. Can be a string or an array. Can also be set with the environment variable `YAMLLS_PATH` using a comma seperated list or an JSON array.
 - **initTimeoutSeconds**: The timeout in seconds for the initialization of yamlls. (Increase if you get an error log like "Error initializing yamlls context deadline exceeded")
 - **Diagnostics Settings**:
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You can configure helm-ls with lsp workspace configurations.
 
 - **Enable yaml-language-server**: Toggle support of this feature.
 - **EnabledForFilesGlob**: A glob pattern defining for which files yaml-language-server should be enabled.
-- **Path to yaml-language-server**: Specify the executable location. Can be a string or an array. Can also be set with the environment variable `YAMLLS_PATH` using a comma seperated list or an JSON array.
+- **Path to yaml-language-server**: Specify the executable location. Can be a string or an array. Can also be set with the environment variable `YAMLLS_PATH` using a comma separated list or a JSON array.
 - **initTimeoutSeconds**: The timeout in seconds for the initialization of yamlls. (Increase if you get an error log like "Error initializing yamlls context deadline exceeded")
 - **Diagnostics Settings**:
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You can configure helm-ls with lsp workspace configurations.
 
 - **Enable yaml-language-server**: Toggle support of this feature.
 - **EnabledForFilesGlob**: A glob pattern defining for which files yaml-language-server should be enabled.
-- **Path to yaml-language-server**: Specify the executable location. Can be a string or an array.
+- **Path to yaml-language-server**: Specify the executable location. Can be a string or an array. Can also be set with the environment variable `YAMLLS_PATH`.
 - **initTimeoutSeconds**: The timeout in seconds for the initialization of yamlls. (Increase if you get an error log like "Error initializing yamlls context deadline exceeded")
 - **Diagnostics Settings**:
 

--- a/internal/handler/configuration.go
+++ b/internal/handler/configuration.go
@@ -44,6 +44,7 @@ func (h *ServerHandler) retrieveWorkspaceConfiguration(ctx context.Context) {
 
 	h.helmlsConfig = parseWorkspaceConfiguration(rawResult, h.helmlsConfig)
 	h.helmlsConfig.YamllsConfiguration.CompileEnabledForFilesGlobObject()
+	h.helmlsConfig.YamllsConfiguration.UpdatePathFromEnv()
 	logger.Println("Workspace configuration:", h.helmlsConfig)
 	h.initializationWithConfig(ctx)
 }

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -99,15 +99,26 @@ func (y *YamllsConfiguration) CompileEnabledForFilesGlobObject() {
 
 func (y *YamllsConfiguration) UpdatePathFromEnv() {
 	if raw, ok := os.LookupEnv(YAMLLS_PATH_ENV_VAR); ok {
-		parts := strings.Split(raw, ",")
-		cleaned := make([]string, 0, len(parts))
-		for _, p := range parts {
-			if s := strings.TrimSpace(p); s != "" {
-				cleaned = append(cleaned, s)
+		var cleaned []string
+
+		// Try to parse as JSON array first
+		if err := json.Unmarshal([]byte(raw), &cleaned); err == nil {
+			// Successfully parsed as JSON array
+			if len(cleaned) > 0 {
+				y.Path = cleaned
 			}
-		}
-		if len(cleaned) > 0 {
-			y.Path = cleaned
+		} else {
+			// Fall back to comma-separated format
+			parts := strings.Split(raw, ",")
+			cleaned := make([]string, 0, len(parts))
+			for _, p := range parts {
+				if s := strings.TrimSpace(p); s != "" {
+					cleaned = append(cleaned, s)
+				}
+			}
+			if len(cleaned) > 0 {
+				y.Path = cleaned
+			}
 		}
 	}
 }

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"encoding/json"
+	"os"
 	"reflect"
+	"strings"
 
 	"github.com/gobwas/glob"
 )
@@ -68,6 +70,8 @@ func (p *YamllsPath) GetArgs() []string {
 	return requiredArgs
 }
 
+const YAMLLS_PATH_ENV_VAR = "YAMLLS_PATH"
+
 type YamllsConfiguration struct {
 	Enabled                   bool   `json:"enabled,omitempty"`
 	EnabledForFilesGlob       string `json:"enabledForFilesGlob,omitempty"`
@@ -91,6 +95,13 @@ func (y *YamllsConfiguration) CompileEnabledForFilesGlobObject() {
 		globObject = DefaultConfig.YamllsConfiguration.EnabledForFilesGlobObject
 	}
 	y.EnabledForFilesGlobObject = globObject
+}
+
+func (y *YamllsConfiguration) UpdatePathFromEnv() {
+	path := os.Getenv(YAMLLS_PATH_ENV_VAR)
+	if path != "" {
+		y.Path = strings.Split(path, ",")
+	}
 }
 
 var DefaultConfig = HelmlsConfiguration{

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -98,9 +98,17 @@ func (y *YamllsConfiguration) CompileEnabledForFilesGlobObject() {
 }
 
 func (y *YamllsConfiguration) UpdatePathFromEnv() {
-	path := os.Getenv(YAMLLS_PATH_ENV_VAR)
-	if path != "" {
-		y.Path = strings.Split(path, ",")
+	if raw, ok := os.LookupEnv(YAMLLS_PATH_ENV_VAR); ok {
+		parts := strings.Split(raw, ",")
+		cleaned := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if s := strings.TrimSpace(p); s != "" {
+				cleaned = append(cleaned, s)
+			}
+		}
+		if len(cleaned) > 0 {
+			y.Path = cleaned
+		}
 	}
 }
 

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -79,6 +79,11 @@ func TestUpdatePathFromEnv(t *testing.T) {
 			envValue: "",
 			expected: nil,
 		},
+		{
+			name:     "JSON array",
+			envValue: `["/path/one" , "/path/two" , "/path/three"]`,
+			expected: YamllsPath{"/path/one", "/path/two", "/path/three"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -55,42 +55,44 @@ func TestYamllsPath_UnmarshalJSON(t *testing.T) {
 }
 
 func TestUpdatePathFromEnv(t *testing.T) {
-	// Set up the environment variable for the test
-	os.Setenv(YAMLLS_PATH_ENV_VAR, "/test/path")
+	tests := []struct {
+		name     string
+		envValue string
+		expected YamllsPath
+	}{
+		{
+			name:     "Single Path",
+			envValue: "/test/path",
+			expected: YamllsPath{"/test/path"},
+		},
+		{
+			name:     "Multiple Paths",
+			envValue: "/test/path,yamlls.js",
+			expected: YamllsPath{"/test/path", "yamlls.js"},
+		},
+		{
+			name:     "Empty Path",
+			envValue: "",
+			expected: nil,
+		},
+	}
 
-	config := &YamllsConfiguration{}
-	config.UpdatePathFromEnv()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(YAMLLS_PATH_ENV_VAR, tt.envValue)
+			} else {
+				os.Unsetenv(YAMLLS_PATH_ENV_VAR)
+			}
 
-	// Use assert to check the expected value
-	assert.Equal(t, YamllsPath{"/test/path"}, config.Path, "The path should be updated to the environment variable value")
+			config := &YamllsConfiguration{}
+			config.UpdatePathFromEnv()
 
-	// Clean up the environment variable
-	os.Unsetenv(YAMLLS_PATH_ENV_VAR)
-}
+			assert.Equal(t, tt.expected, config.Path, "The path should be updated to the environment variable value")
 
-func TestUpdatePathFromEnvSplit(t *testing.T) {
-	// Set up the environment variable for the test
-	os.Setenv(YAMLLS_PATH_ENV_VAR, "/test/path, yamlls.js")
-
-	config := &YamllsConfiguration{}
-	config.UpdatePathFromEnv()
-
-	// Use assert to check the expected value
-	assert.Equal(t, YamllsPath{"/test/path", " yamlls.js"}, config.Path, "The path should be updated to the environment variable value")
-
-	// Clean up the environment variable
-	os.Unsetenv(YAMLLS_PATH_ENV_VAR)
-}
-
-func TestUpdatePathFromEnv_Empty(t *testing.T) {
-	// Ensure the environment variable is not set
-	os.Unsetenv(YAMLLS_PATH_ENV_VAR)
-
-	config := &YamllsConfiguration{}
-	config.UpdatePathFromEnv()
-
-	// Use assert to check the expected value
-	assert.Empty(t, config.Path, "The path should be empty when the environment variable is not set")
+			os.Unsetenv(YAMLLS_PATH_ENV_VAR)
+		})
+	}
 }
 
 func TestYamllsPath_GetExecutable(t *testing.T) {

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +52,45 @@ func TestYamllsPath_UnmarshalJSON(t *testing.T) {
 			assert.Equal(t, tt.expected, path)
 		})
 	}
+}
+
+func TestUpdatePathFromEnv(t *testing.T) {
+	// Set up the environment variable for the test
+	os.Setenv(YAMLLS_PATH_ENV_VAR, "/test/path")
+
+	config := &YamllsConfiguration{}
+	config.UpdatePathFromEnv()
+
+	// Use assert to check the expected value
+	assert.Equal(t, YamllsPath{"/test/path"}, config.Path, "The path should be updated to the environment variable value")
+
+	// Clean up the environment variable
+	os.Unsetenv(YAMLLS_PATH_ENV_VAR)
+}
+
+func TestUpdatePathFromEnvSplit(t *testing.T) {
+	// Set up the environment variable for the test
+	os.Setenv(YAMLLS_PATH_ENV_VAR, "/test/path, yamlls.js")
+
+	config := &YamllsConfiguration{}
+	config.UpdatePathFromEnv()
+
+	// Use assert to check the expected value
+	assert.Equal(t, YamllsPath{"/test/path", " yamlls.js"}, config.Path, "The path should be updated to the environment variable value")
+
+	// Clean up the environment variable
+	os.Unsetenv(YAMLLS_PATH_ENV_VAR)
+}
+
+func TestUpdatePathFromEnv_Empty(t *testing.T) {
+	// Ensure the environment variable is not set
+	os.Unsetenv(YAMLLS_PATH_ENV_VAR)
+
+	config := &YamllsConfiguration{}
+	config.UpdatePathFromEnv()
+
+	// Use assert to check the expected value
+	assert.Empty(t, config.Path, "The path should be empty when the environment variable is not set")
 }
 
 func TestYamllsPath_GetExecutable(t *testing.T) {

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +70,11 @@ func TestUpdatePathFromEnv(t *testing.T) {
 			expected: YamllsPath{"/test/path", "yamlls.js"},
 		},
 		{
+			name:     "Multiple Paths with spaces",
+			envValue: "/test/path , yamlls.js",
+			expected: YamllsPath{"/test/path", "yamlls.js"},
+		},
+		{
 			name:     "Empty Path",
 			envValue: "",
 			expected: nil,
@@ -80,17 +84,13 @@ func TestUpdatePathFromEnv(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envValue != "" {
-				os.Setenv(YAMLLS_PATH_ENV_VAR, tt.envValue)
-			} else {
-				os.Unsetenv(YAMLLS_PATH_ENV_VAR)
+				t.Setenv(YAMLLS_PATH_ENV_VAR, tt.envValue)
 			}
 
 			config := &YamllsConfiguration{}
 			config.UpdatePathFromEnv()
 
 			assert.Equal(t, tt.expected, config.Path, "The path should be updated to the environment variable value")
-
-			os.Unsetenv(YAMLLS_PATH_ENV_VAR)
 		})
 	}
 }


### PR DESCRIPTION
required for https://github.com/qvalentin/helm-ls-vscode/issues/8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure YAML language server path via the YAMLLS_PATH environment variable (supports comma-separated values or JSON array); applied during workspace initialization.

* **Documentation**
  * README clarifies YAMLLS_PATH can be used in addition to existing configuration options.

* **Tests**
  * Added tests for single, multiple (comma-separated and JSON array), trimmed, and empty YAMLLS_PATH scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->